### PR TITLE
Fix the link to the latest release

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         </header>
 
         <section id="downloads" class="clearfix">
-          <a href="https://github.com/open744/terramaster/releases/download/v1.2/terramaster.jar" id="download-jar" class="button"><span>Download v1.2</span></a>
+          <a href="https://github.com/open744/terramaster/releases/download/1.2/terramaster.jar" id="download-jar" class="button"><span>Download v1.2</span></a>
           <!--
           <a href="https://github.com/open744/terramaster/zipball/master" id="download-zip" class="button"><span>Download source .zip</span></a>
           <a href="https://github.com/open744/terramaster/tarball/master" id="download-tar-gz" class="button"><span>Download source .tar.gz</span></a>


### PR DESCRIPTION
Remove the "v" in the link to the latest release (seems like GitHub removed it, breaking the existing link).